### PR TITLE
Fix broken Graph View

### DIFF
--- a/tf-graph/tf-graph-basic.build.html
+++ b/tf-graph/tf-graph-basic.build.html
@@ -1053,4 +1053,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </template>
 </dom-module>
 
-<script src="tf-graph-basic.build.js"></script></body></html>
+<script src="tf-graph-basic.build.js"></script>
+<script>
+function iframe_hook(event){
+  event.target.pbtxt = decodeURI(window.location.hash.substr(1));
+}
+</script>
+<div style="height:600px">
+  <tf-graph-basic onload="iframe_hook"></tf-graph-basic>
+</div>
+  
+</body></html>

--- a/tf-graph/tf-graph-basic.build.html
+++ b/tf-graph/tf-graph-basic.build.html
@@ -1056,7 +1056,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script src="tf-graph-basic.build.js"></script>
 <script>
 function iframe_hook(event){
-  event.target.pbtxt = decodeURI(window.location.hash.substr(1));
+  event.target.pbtxt = atob(decodeURI(window.location.hash.substr(1)));
 }
 </script>
 <div style="height:600px">

--- a/tf-graph/tf-graph-basic.build.html
+++ b/tf-graph/tf-graph-basic.build.html
@@ -1054,13 +1054,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script src="tf-graph-basic.build.js"></script>
+<div style="height:600px">
+  <tf-graph-basic id="custom-graph"></tf-graph-basic>
+</div>
 <script>
-function iframe_hook(event){
-  event.target.pbtxt = atob(decodeURI(window.location.hash.substr(1)));
+window.onload = (event)=>{
+  document.getElementById("custom-graph").pbtxt = atob(decodeURI(window.location.hash.substr(1)));
 }
 </script>
-<div style="height:600px">
-  <tf-graph-basic onload="iframe_hook"></tf-graph-basic>
-</div>
-  
 </body></html>

--- a/tf-graph/tf-graph-basic.build.js
+++ b/tf-graph/tf-graph-basic.build.js
@@ -38447,7 +38447,7 @@ return this.disabled || !this.required || this.required && this.value;
 Polymer({
 is: 'tf-graph-controls',
 ready: function () {
-d3.select(this.$['summary-icon']).attr('xlink:href', '/files/tf-graph/summary-icon.svg');
+d3.select(this.$['summary-icon']).attr('xlink:href', 'summary-icon.svg');
 },
 properties: {
 hasStats: { type: Boolean },


### PR DESCRIPTION
A common endpoint for viewing graphs in notebooks was: http://tensorboard.appspot.com/tf-graph-basic.build.html

Note that this link is now dead! I'm not sure whether this code was modified from appspot app or visa versa, but it it the only living copy of `tf-graph-basic.build.html` I can find. As of recent chrome updates `<link rel=X>` for importing HTML does not work, as such we move the polymer definitions into the file and pass the data as a base64 encoded `location.hash`. This method also allows for hosting the static page off server (work around for coors).

Note that GET requests are limited in size, thus super large graphs will NOT be visible. However, this was more a "trying to figure out what's wrong" rather than a "let's come up with a permanent fix", and meets my purposes.